### PR TITLE
build(renovate): fix plugin dependency lookup warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Use a set of Pocket-wide defaults. See [Pocket/renovate-config](https://github.c
 for more details and documentation.
 ```json
 {
-  "ignorePaths": ["buildSrc/**"]
+  "ignorePaths": ["buildSrc/src/main/kotlin/Deps.kt"]
 }
 ```
 Ignore our legacy dependency definitions in `buildSrc`, while we gradually migrate to version catalog.
@@ -102,6 +102,19 @@ to let a human decide before merging.
 }
 ```
 Tweak the default commit message a bit to cut a redundant word from already pretty long messages.
+
+```json
+{
+  "packageRules": [
+    {
+      "matchDepNames": ["plugin-*"],
+      "semanticCommitType": "chore"
+    }
+  ]
+}
+```
+Update semantic commit rules to account for our custom plugin definitions
+(because of defining them in `buildSrc`).
 
 ### Sync Engine
 

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": [
     "local>Pocket/renovate-config"
   ],
-  "ignorePaths": ["buildSrc/**"],
+  "ignorePaths": ["buildSrc/src/main/kotlin/Deps.kt"],
   "ignorePresets": [":dependencyDashboardApproval"],
   "packageRules": [
     {
@@ -13,6 +13,10 @@
     {
       "matchManagers": ["gradle", "gradle-wrapper"],
       "commitMessageTopic": "{{depName}}"
+    },
+    {
+      "matchDepNames": ["plugin-*"],
+      "semanticCommitType": "chore"
     }
   ]
 }


### PR DESCRIPTION
<!--
Start with a simple 1-2 sentence summary of the goal of this PR.
If there's more you want to add add more paragraphs to elaborate.
-->
Noticed a "Dependency Lookup Warning", because of recently introduced About Libraries. Looks like the gradle plugin is only available in gradle plugin portal. But renovate doesn't recognise it as one of the maven repositories, probably because I ignored the entire `buildSrc` directory. Let's see if this helps

Additionally I added experimental config that tries to set a more accurate semantic commit scope for plugin updates. It's something I sometimes manually have to adjust and did it as recently as today, so it was top of mind to try to automate it.

## References

<!-- Links to docs, tickets, designs if available -->

## PR Checklist
<!-- Items in comments are optional, please review them and uncomment any that apply to this PR. -->
Setup:
* [x] Described changes for automated release notes in PR title using
  [Conventional Commits](https://mozilla-hub.atlassian.net/wiki/spaces/PE/pages/390658939/Commit+Message+Standard) standard
* [x] Self Review (review, clean up, documentation)
* [ ] Basic Self QA
<!--
* [ ] Feature flagged as needed to ensure this specific code is beta and production ready
* [ ] Added `ignore-for-release` label because:
  * (choose applicable reason or add your own, delete the rest)
  * this fixes or changes something introduced after the last public release
  * this is hidden behind a feature flag that is disabled in public builds
  * this is part of a larger body of work that needs to be called out only once in release notes
-->

Review:
* [ ] Code Review approved
<!--
* [ ] If modified GraphQL spec or queries, checked the usage file for invalid or no longer used definitions and [cleaned it up](https://mozilla-hub.atlassian.net/wiki/spaces/PE/pages/390645389/Development+Workflow#Final-checks) if necessary
-->

<!-- Optional section for cases where we might need to do some tasks after the code is approved and merged.
After merge:
* [ ] Create the new feature flag in [Unleash](https://featureflags.readitlater.com/).
* [ ] Archive the deleted feature flag in [Unleash](https://featureflags.readitlater.com/).
* [ ] Update [Pocket Analytics spreadsheet](https://docs.google.com/spreadsheets/d/10DrvRWaRjHbhvdoetVqeScK452alaSUtXpgdLGtEs3A/edit).
-->

<!-- If you opened this PR with `git spr` feel free to copy anything it generated here into the PR body.
If you haven't used `git spr` or don't even know what it is feel free to ignore it or remove it from your PR.

Please don't remove it from PR template, unless you confirm with the team that nobody is using `git spr` anymore.

See:
* `.spr.yml` in this repo
* https://github.com/ejoffe/spr
spr -->
