### PR TITLE
fix(home): fix see all sometimes opening empty screen

### DIFF
--- a/Pocket/src/main/java/com/pocket/app/home/Home.kt
+++ b/Pocket/src/main/java/com/pocket/app/home/Home.kt
@@ -19,7 +19,7 @@ class Home {
             corpusRecommendationId: String?,
         )
         fun onSeeAllRecommendationsClicked(
-            slateId: String,
+            index: Int,
             slateTitle: String
         )
         fun onSaveClicked(url: String, isSaved: Boolean, corpusRecommendationId: String?)
@@ -70,7 +70,7 @@ class Home {
         data object GoToMyList : Event()
 
         data class GoToSlateDetails(
-            val slateId: String,
+            val index: Int,
         ) : Event()
 
         data class GoToTopicDetails(

--- a/Pocket/src/main/java/com/pocket/app/home/HomeFragment.kt
+++ b/Pocket/src/main/java/com/pocket/app/home/HomeFragment.kt
@@ -143,7 +143,7 @@ class HomeFragment : AbsPocketFragment() {
             }
             is Home.Event.GoToSlateDetails -> {
                 findNavController().navigateSafely(
-                    HomeFragmentDirections.goToSlateDetails(event.slateId)
+                    HomeFragmentDirections.goToSlateDetails(event.index)
                 )
             }
             is Home.Event.GoToTopicDetails -> {

--- a/Pocket/src/main/java/com/pocket/app/home/HomeViewModel.kt
+++ b/Pocket/src/main/java/com/pocket/app/home/HomeViewModel.kt
@@ -202,7 +202,6 @@ class HomeViewModel @Inject constructor(
                     // Report and filter out.
                     errorHandler.reportOnProductionOrThrow(RuntimeException(
                         "Slate is empty: " + listOf(
-                            "id = ${slate.id}",
                             "title = ${slate.title}",
                             "locale = $localeString",
                         )
@@ -287,9 +286,9 @@ class HomeViewModel @Inject constructor(
         )
     }
 
-    override fun onSeeAllRecommendationsClicked(slateId: String, slateTitle: String) {
+    override fun onSeeAllRecommendationsClicked(index: Int, slateTitle: String) {
         tracker.track(HomeEvents.slateSeeAllClicked(slateTitle = slateTitle))
-        _events.tryEmit(Home.Event.GoToSlateDetails(slateId))
+        _events.tryEmit(Home.Event.GoToSlateDetails(index))
     }
 
     override fun onTopicClicked(topicId: String, topicTitle: String) {
@@ -380,10 +379,7 @@ class HomeViewModel @Inject constructor(
         val title: String?,
         val subheadline: String?,
         val recommendations: List<RecommendationUiState>,
-    ) {
-        // Exclude slate id from `.equals()` etc., because it's not stable.
-        lateinit var slateId: String
-    }
+    )
 
     private fun DomainSlate.toRecommendationSlateUiState(
         stringLoader: StringLoader,
@@ -394,9 +390,7 @@ class HomeViewModel @Inject constructor(
         recommendations = recommendations
             .map { it.toRecommendationUiState(stringLoader) }
             .take(recommendationsPerSlate)
-    ).apply {
-        slateId = id
-    }
+    )
 
 
     data class TopicUiState(

--- a/Pocket/src/main/java/com/pocket/app/home/details/slates/SlateDetailsFragment.kt
+++ b/Pocket/src/main/java/com/pocket/app/home/details/slates/SlateDetailsFragment.kt
@@ -39,7 +39,7 @@ class SlateDetailsFragment : DetailsFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        viewModel.onInitialized(args.slateId)
+        viewModel.onInitialized(args.index)
     }
 
     override fun goToReader(event: DetailsViewModel.Event.GoToReader) {

--- a/Pocket/src/main/java/com/pocket/app/home/details/slates/SlateDetailsViewModel.kt
+++ b/Pocket/src/main/java/com/pocket/app/home/details/slates/SlateDetailsViewModel.kt
@@ -29,12 +29,12 @@ class SlateDetailsViewModel @Inject constructor(
     itemRepository = itemRepository,
     save = save,
     tracker = tracker,
-), SlateDetailsInteractions {
+) {
 
     private val localeString = locale.toString()
 
-    override fun onInitialized(slateId: String) {
-        setupSlateCollector(slateId)
+    fun onInitialized(index: Int) {
+        setupSlateCollector(index)
         _uiState.edit {
             copy(
                 screenState = ScreenState.Recommendations
@@ -42,10 +42,10 @@ class SlateDetailsViewModel @Inject constructor(
         }
     }
 
-    private fun setupSlateCollector(slateId: String) {
+    private fun setupSlateCollector(index: Int) {
         viewModelScope.launch {
             homeRepository.getLineup(localeString).collect { lineup ->
-                val slate = lineup.find { it.id == slateId }
+                val slate = lineup.getOrNull(index)
                 _uiState.edit {
                     copy(
                         title = slate?.title ?: "",
@@ -84,8 +84,4 @@ class SlateDetailsViewModel @Inject constructor(
             )
         )
     }
-}
-
-interface SlateDetailsInteractions {
-    fun onInitialized(slateId: String)
 }

--- a/Pocket/src/main/java/com/pocket/app/home/slates/SlatesAdapter.kt
+++ b/Pocket/src/main/java/com/pocket/app/home/slates/SlatesAdapter.kt
@@ -52,8 +52,8 @@ class SlatesAdapter(
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) =
         when (holder) {
-            is SlateViewHolder -> holder.bind(getItem(position))
-            is SlatesTabletViewHolder -> holder.bind(getItem(position))
+            is SlateViewHolder -> holder.bind(getItem(position), position)
+            is SlatesTabletViewHolder -> holder.bind(getItem(position), position)
             else -> {}
         }
 
@@ -84,7 +84,7 @@ class SlatesAdapter(
             binding.minorCardRecyclerView.itemAnimator = null
         }
 
-        fun bind(state: HomeViewModel.RecommendationSlateUiState) {
+        fun bind(state: HomeViewModel.RecommendationSlateUiState, position: Int) {
             binding.title.text = state.title
             if (state.subheadline != null) {
                 binding.subtitle.text = state.subheadline
@@ -93,9 +93,7 @@ class SlatesAdapter(
             }
             binding.slateSeeAllLayout.apply {
                 setOnClickListener {
-                    if (state.slateId.isNotBlank()) {
-                        viewModel.onSeeAllRecommendationsClicked(state.slateId, state.title.orEmpty())
-                    }
+                    viewModel.onSeeAllRecommendationsClicked(position, state.title.orEmpty())
                 }
                 engageable.uiEntityComponentDetail = state.title
             }
@@ -139,7 +137,7 @@ class SlatesAdapter(
             binding.minorCardRecyclerView.itemAnimator = null
         }
 
-        fun bind(state: HomeViewModel.RecommendationSlateUiState) {
+        fun bind(state: HomeViewModel.RecommendationSlateUiState, position: Int) {
             binding.title.text = state.title
             if (state.subheadline != null) {
                 binding.subtitle.text = state.subheadline
@@ -147,9 +145,7 @@ class SlatesAdapter(
                 binding.subtitle.visibility = GONE
             }
             binding.seeAllLayout.setOnClickListener {
-                if (state.slateId.isNotBlank()) {
-                    viewModel.onSeeAllRecommendationsClicked(state.slateId, state.title.orEmpty())
-                }
+                viewModel.onSeeAllRecommendationsClicked(position, state.title.orEmpty())
             }
 
             // first item goes to the hero card

--- a/Pocket/src/main/java/com/pocket/data/models/DomainSlate.kt
+++ b/Pocket/src/main/java/com/pocket/data/models/DomainSlate.kt
@@ -3,6 +3,5 @@ package com.pocket.data.models
 data class DomainSlate(
     val title: String?,
     val subheadline: String?,
-    val id: String,
     val recommendations: List<DomainRecommendation>
 )

--- a/Pocket/src/main/java/com/pocket/repository/HomeRepository.kt
+++ b/Pocket/src/main/java/com/pocket/repository/HomeRepository.kt
@@ -82,7 +82,6 @@ fun CorpusSlate.toDomainSlate(): DomainSlate =
     DomainSlate(
         title = headline,
         subheadline = subheadline,
-        id = id?.id!!,
         recommendations = recommendations?.mapIndexed { index, corpusRecommendation ->
             corpusRecommendation.toRecommendation(index)
         } ?: listOf(),

--- a/Pocket/src/main/res/navigation/main_graph.xml
+++ b/Pocket/src/main/res/navigation/main_graph.xml
@@ -89,7 +89,7 @@
         android:label="SlateDetailsFragment"
         tools:layout="@layout/fragment_home_details">
         
-        <argument android:name="slateId" app:argType="string"/>
+        <argument android:name="index" app:argType="integer" />
     
         <action
             android:id="@+id/slateDetailsToReader"

--- a/Pocket/src/test/java/com/pocket/app/home/HomeViewModelTest.kt
+++ b/Pocket/src/test/java/com/pocket/app/home/HomeViewModelTest.kt
@@ -117,9 +117,9 @@ class HomeViewModelTest : BaseCoroutineTest() {
         subject.onInitialized()
         homeSlateLineup.emit(
             listOf(
-                DomainSlate(null, null, "1", listOf(testRecommendation)),
-                DomainSlate("empty", null, "2", emptyList()),
-                DomainSlate(null, null, "3", listOf(testRecommendation)),
+                DomainSlate(null, null, listOf(testRecommendation)),
+                DomainSlate("empty", null, emptyList()),
+                DomainSlate(null, null, listOf(testRecommendation)),
             )
         )
 


### PR DESCRIPTION
In this episode of Slate IDs Don't Matter it turned out we load slates by slate id on the details screen. And if you click "See all" while Home is refreshing, you'll start the screen with an id, but when the network request comes back all the ids will change and the screen won't find a slate with this id and will show and empty screen.

In this case opening by index is more reliable. The only bad things that could happen is if we remove a slate or reorder them. Then someone could see a different slate than the one they clicked. Unless we reorder slates on each refresh, they should be able to just go back and reopen to get the correct one.

## References

<!-- Links to docs, tickets, designs if available -->

## PR Checklist
<!-- Items in comments are optional, please review them and uncomment any that apply to this PR. -->
Setup:
* [x] Described changes for automated release notes in PR title using
  [Conventional Commits](https://mozilla-hub.atlassian.net/wiki/spaces/PE/pages/390658939/Commit+Message+Standard) standard
* [x] Self Review (review, clean up, documentation)
* [x] Basic Self QA
<!--
* [ ] Feature flagged as needed to ensure this specific code is beta and production ready
* [ ] Added `ignore-for-release` label because:
  * (choose applicable reason or add your own, delete the rest)
  * this fixes or changes something introduced after the last public release
  * this is hidden behind a feature flag that is disabled in public builds
  * this is part of a larger body of work that needs to be called out only once in release notes
-->

Review:
* [ ] Code Review approved
<!--
* [ ] If modified GraphQL spec or queries, checked the usage file for invalid or no longer used definitions and [cleaned it up](https://mozilla-hub.atlassian.net/wiki/spaces/PE/pages/390645389/Development+Workflow#Final-checks) if necessary
-->

<!-- Optional section for cases where we might need to do some tasks after the code is approved and merged.
After merge:
* [ ] Create the new feature flag in [Unleash](https://featureflags.readitlater.com/).
* [ ] Archive the deleted feature flag in [Unleash](https://featureflags.readitlater.com/).
* [ ] Update [Pocket Analytics spreadsheet](https://docs.google.com/spreadsheets/d/10DrvRWaRjHbhvdoetVqeScK452alaSUtXpgdLGtEs3A/edit).
-->

<!-- If you opened this PR with `git spr` feel free to copy anything it generated here into the PR body.
If you haven't used `git spr` or don't even know what it is feel free to ignore it or remove it from your PR.

Please don't remove it from PR template, unless you confirm with the team that nobody is using `git spr` anymore.

See:
* `.spr.yml` in this repo
* https://github.com/ejoffe/spr
spr -->
