### PR TITLE
build(renovate): add custom datasource for r8 versions

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -28,6 +28,14 @@
       matchManagers: ['gradle', 'gradle-wrapper'],
       commitMessageTopic: '{{depName}}',
     },
+    // Use a custom R8 datasource, because R8 repository is not a full Maven repository
+    // and doesn't expose available versions for Renovate.
+    {
+      matchPackageNames: [
+        'com.android.tools:r8'
+      ],
+      overrideDatasource: 'custom.r8',
+    },
   ],
   customManagers: [
     // Update .java-version file with the latest JDK version.
@@ -46,4 +54,22 @@
       extractVersionTemplate: '^(?<version>\\d+)',
     },
   ],
+  customDatasources: {
+    // Check the available r8 versions from a specific release branch in the r8 repository,
+    // by extracting them from commit messages.
+    r8: {
+      // Workaround: This requests a response in JSON format (via the query parameter in the URL),
+      // but instructs Renovate to treat it as plain text. It's because the response contains some
+      // extra junk characters at the beginning, so the JSON parser rejects it as invalid.
+      // So instead this just finds the versions by regex in the JSON text, without parsing it
+      // as a JSON object.
+      // It doesn't work just specifying `format: 'plain'`, because the "API" rejects `text/plain`
+      // as an unsupported response format.
+      defaultRegistryUrlTemplate: 'https://r8.googlesource.com/r8/+log/refs/heads/8.8/src/main/java/com/android/tools/r8/Version.java?format=JSON',
+      format: 'plain',
+      transformTemplates: [
+        '{"releases": releases.{"version": $match(version, /^"message": "Version ([0-9\.]+)/).groups[0]}[version]}'
+      ]
+    }
+  },
 }


### PR DESCRIPTION
Add a custom R8 datasource, because R8 repository is not in fact a real Maven repository. In the authors' own words (emphasis mine):
> The Google Cloud Storage bucket r8-releases can also be used as a **simple** Maven repository

This fixes Renovate not being able to detect new R8 versions.

This is currently hardcoded to R8's 8.8 release branch. For now it would have to be manually updated (in Renovate config) to switch to a newer release branch, for example after updating AGP to 8.9. I think it's possible to further change the config to automatically switch to the next branch when AGP updates, but this is a future improvement.

## References

* https://r8.googlesource.com/r8/#obtaining-prebuilts
* https://docs.renovatebot.com/modules/datasource/custom/
* https://docs.jsonata.org/

## PR Checklist
<!-- Items in comments are optional, please review them and uncomment any that apply to this PR. -->
Setup:
* [x] Described changes for automated release notes in PR title using
  [Conventional Commits](https://mozilla-hub.atlassian.net/wiki/spaces/PE/pages/390658939/Commit+Message+Standard) standard
* [x] Self Review (review, clean up, documentation)
* [x] Basic Self QA
<!--
* [ ] Feature flagged as needed to ensure this specific code is beta and production ready
* [ ] Added `ignore-for-release` label because:
  * (choose applicable reason or add your own, delete the rest)
  * this fixes or changes something introduced after the last public release
  * this is hidden behind a feature flag that is disabled in public builds
  * this is part of a larger body of work that needs to be called out only once in release notes
-->

Review:
* [ ] Code Review approved
<!--
* [ ] If modified GraphQL spec or queries, checked the usage file for invalid or no longer used definitions and [cleaned it up](https://mozilla-hub.atlassian.net/wiki/spaces/PE/pages/390645389/Development+Workflow#Final-checks) if necessary
-->

<!-- Optional section for cases where we might need to do some tasks after the code is approved and merged.
After merge:
* [ ] Create the new feature flag in [Unleash](https://featureflags.readitlater.com/).
* [ ] Archive the deleted feature flag in [Unleash](https://featureflags.readitlater.com/).
* [ ] Update [Pocket Analytics spreadsheet](https://docs.google.com/spreadsheets/d/10DrvRWaRjHbhvdoetVqeScK452alaSUtXpgdLGtEs3A/edit).
-->

<!-- If you opened this PR with `git spr` feel free to copy anything it generated here into the PR body.
If you haven't used `git spr` or don't even know what it is feel free to ignore it or remove it from your PR.

Please don't remove it from PR template, unless you confirm with the team that nobody is using `git spr` anymore.

See:
* `.spr.yml` in this repo
* https://github.com/ejoffe/spr
spr -->
