### PR TITLE
build(renovate): override r8 registry urls detected by gradle manager

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -35,6 +35,9 @@
         'com.android.tools:r8'
       ],
       overrideDatasource: 'custom.r8',
+      registryUrls: [
+        'https://r8.googlesource.com/r8/+log/refs/heads/8.8/src/main/java/com/android/tools/r8/Version.java?format=JSON'
+      ],
     },
   ],
   customManagers: [
@@ -65,7 +68,6 @@
       // as a JSON object.
       // It doesn't work just specifying `format: 'plain'`, because the "API" rejects `text/plain`
       // as an unsupported response format.
-      defaultRegistryUrlTemplate: 'https://r8.googlesource.com/r8/+log/refs/heads/8.8/src/main/java/com/android/tools/r8/Version.java?format=JSON',
       format: 'plain',
       transformTemplates: [
         '{"releases": releases.{"version": $match(version, /^"message": "Version ([0-9\.]+)/).groups[0]}[version]}'


### PR DESCRIPTION
Turns out using the custom r8 data source works slightly differently with our bespoke setup with `buildSrc` and what-not than in a simple sample I used for testing. Shocking I know. Anyway, Looks like I need to explicitly override "registry URLs" detected for R8, instead of specifying the correct URL as default in the data source.

## References

* https://docs.renovatebot.com/configuration-options/#registryurls

## PR Checklist
<!-- Items in comments are optional, please review them and uncomment any that apply to this PR. -->
Setup:
* [x] Described changes for automated release notes in PR title using
  [Conventional Commits](https://mozilla-hub.atlassian.net/wiki/spaces/PE/pages/390658939/Commit+Message+Standard) standard
* [x] Self Review (review, clean up, documentation)
* [ ] Basic Self QA
<!--
* [ ] Feature flagged as needed to ensure this specific code is beta and production ready
* [ ] Added `ignore-for-release` label because:
  * (choose applicable reason or add your own, delete the rest)
  * this fixes or changes something introduced after the last public release
  * this is hidden behind a feature flag that is disabled in public builds
  * this is part of a larger body of work that needs to be called out only once in release notes
-->

Review:
* [ ] Code Review approved
<!--
* [ ] If modified GraphQL spec or queries, checked the usage file for invalid or no longer used definitions and [cleaned it up](https://mozilla-hub.atlassian.net/wiki/spaces/PE/pages/390645389/Development+Workflow#Final-checks) if necessary
-->

<!-- Optional section for cases where we might need to do some tasks after the code is approved and merged.
After merge:
* [ ] Create the new feature flag in [Unleash](https://featureflags.readitlater.com/).
* [ ] Archive the deleted feature flag in [Unleash](https://featureflags.readitlater.com/).
* [ ] Update [Pocket Analytics spreadsheet](https://docs.google.com/spreadsheets/d/10DrvRWaRjHbhvdoetVqeScK452alaSUtXpgdLGtEs3A/edit).
-->

<!-- If you opened this PR with `git spr` feel free to copy anything it generated here into the PR body.
If you haven't used `git spr` or don't even know what it is feel free to ignore it or remove it from your PR.

Please don't remove it from PR template, unless you confirm with the team that nobody is using `git spr` anymore.

See:
* `.spr.yml` in this repo
* https://github.com/ejoffe/spr
spr -->
