### PR TITLE
build(renovate): switch r8 data source to html to also capture digest

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -36,7 +36,7 @@
       ],
       overrideDatasource: 'custom.r8',
       registryUrls: [
-        'https://r8.googlesource.com/r8/+log/refs/heads/8.8/src/main/java/com/android/tools/r8/Version.java?format=JSON'
+        'https://r8.googlesource.com/r8/+log/refs/heads/8.8/src/main/java/com/android/tools/r8/Version.java?format=HTML'
       ],
     },
   ],
@@ -61,17 +61,22 @@
     // Check the available r8 versions from a specific release branch in the r8 repository,
     // by extracting them from commit messages.
     r8: {
-      // Workaround: This requests a response in JSON format (via the query parameter in the URL),
-      // but instructs Renovate to treat it as plain text. It's because the response contains some
-      // extra junk characters at the beginning, so the JSON parser rejects it as invalid.
-      // So instead this just finds the versions by regex in the JSON text, without parsing it
-      // as a JSON object.
-      // It doesn't work just specifying `format: 'plain'`, because the "API" rejects `text/plain`
-      // as an unsupported response format.
+      // Workaround: This requests an HTML response (via the query parameter in the URL),
+      // but instructs Renovate to treat it as plain text, to do some custom processing
+      // with JSONata and regex, instead of relying on the default HTML processing.
       format: 'plain',
       transformTemplates: [
-        '{"releases": releases.{"version": $match(version, /^"message": "Version ([0-9\.]+)/).groups[0]}[version]}'
-      ]
+        '{\
+            "releases": $split(releases[0].version, "<li class=\\"CommitLog-item ")\
+                .($match(/([^"\\/]+)">Version ([0-9\\.]+)<\\/a>/))\
+                .{\
+                    "digest": groups[0],\
+                    "version": groups[1],\
+                    "isStable": true\
+                },\
+            "sourceUrl": "https://r8.googlesource.com/r8/"\
+        }'
+      ],
     }
   },
 }


### PR DESCRIPTION
Try a new iteration of the custom R8 data source for Renovate. This one is a bit cleaner I think, but more importantly captures the release digest. I don't think we actually need it, but I saw some log messages about missing digest and this might be the reason why it discarded the newer version it was able to find 🤷 

## References

* #124 

## PR Checklist
<!-- Items in comments are optional, please review them and uncomment any that apply to this PR. -->
Setup:
* [x] Described changes for automated release notes in PR title using
  [Conventional Commits](https://mozilla-hub.atlassian.net/wiki/spaces/PE/pages/390658939/Commit+Message+Standard) standard
* [x] Self Review (review, clean up, documentation)
* [ ] Basic Self QA
<!--
* [ ] Feature flagged as needed to ensure this specific code is beta and production ready
-->
* [x] Added `ignore-for-release` label because:
  * this fixes or changes something introduced after the last public release

Review:
* [ ] Code Review approved
<!--
* [ ] If modified GraphQL spec or queries, checked the usage file for invalid or no longer used definitions and [cleaned it up](https://mozilla-hub.atlassian.net/wiki/spaces/PE/pages/390645389/Development+Workflow#Final-checks) if necessary
-->

<!-- Optional section for cases where we might need to do some tasks after the code is approved and merged.
After merge:
* [ ] Create the new feature flag in [Unleash](https://featureflags.readitlater.com/).
* [ ] Archive the deleted feature flag in [Unleash](https://featureflags.readitlater.com/).
* [ ] Update [Pocket Analytics spreadsheet](https://docs.google.com/spreadsheets/d/10DrvRWaRjHbhvdoetVqeScK452alaSUtXpgdLGtEs3A/edit).
-->

<!-- If you opened this PR with `git spr` feel free to copy anything it generated here into the PR body.
If you haven't used `git spr` or don't even know what it is feel free to ignore it or remove it from your PR.

Please don't remove it from PR template, unless you confirm with the team that nobody is using `git spr` anymore.

See:
* `.spr.yml` in this repo
* https://github.com/ejoffe/spr
spr -->
