### PR TITLE
fix(markdown): simplify markdown formatting api

### DIFF
--- a/Pocket/src/main/java/com/pocket/app/reader/internal/collection/CollectionStoryAdapter.kt
+++ b/Pocket/src/main/java/com/pocket/app/reader/internal/collection/CollectionStoryAdapter.kt
@@ -8,8 +8,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.ideashower.readitlater.databinding.ViewHomeHeroCardBinding
-import com.pocket.sdk.api.value.MarkdownString
-import com.pocket.sdk.util.MarkdownHandler
+import com.pocket.sdk.util.MarkdownFormatter
 import com.pocket.sdk2.view.LazyAssetBitmap
 import com.pocket.ui.util.LazyBitmapDrawable
 import com.pocket.util.android.repeatOnCreated
@@ -17,7 +16,7 @@ import com.pocket.util.android.repeatOnCreated
 class CollectionStoryAdapter(
     viewLifecycleOwner: LifecycleOwner,
     private val viewModel: CollectionViewModel,
-    private val markdown: MarkdownHandler,
+    private val markdown: MarkdownFormatter,
     private val corpusRecommendationId: String?,
 ): ListAdapter<CollectionViewModel.StoryUiState,
         CollectionStoryAdapter.ViewHolder>(DIFF_CALLBACK) {
@@ -51,9 +50,8 @@ class CollectionStoryAdapter(
                 title.text = state.title
 
                 excerpt.visibility = View.VISIBLE
-                with(markdown) {
-                    excerpt.setMarkdownString(MarkdownString(state.excerpt))
-                }
+                excerpt.setMovementMethodForLinks(true)
+                excerpt.text = markdown.format(state.excerpt)
 
                 collectionLabel.visibility = if (state.collectionLabelVisible) {
                     View.VISIBLE
@@ -85,7 +83,6 @@ class CollectionStoryAdapter(
                         corpusRecommendationId = corpusRecommendationId,
                     )
                 }
-                excerpt.setOnClickListener { viewModel.onCardClicked(state.url) }
                 root.setOnClickListener { viewModel.onCardClicked(state.url) }
             }
         }

--- a/Pocket/src/main/java/com/pocket/app/settings/account/AccountManagement.kt
+++ b/Pocket/src/main/java/com/pocket/app/settings/account/AccountManagement.kt
@@ -219,7 +219,7 @@ class DeleteAccountFragment : AbsPocketFragment() {
 
             with(cancelPremiumLabel) {
                 applyAnnotations()
-                setMovementMethodForLinks()
+                setMovementMethodForLinks(true)
             }
 
             cancelPremiumCheckbox.setOnCheckedChangeListener { _, isChecked ->

--- a/Pocket/src/main/java/com/pocket/sdk/util/MarkdownFormatter.kt
+++ b/Pocket/src/main/java/com/pocket/sdk/util/MarkdownFormatter.kt
@@ -1,8 +1,6 @@
 package com.pocket.sdk.util
 
 import android.content.Context
-import android.widget.TextView
-import com.pocket.sdk.api.value.MarkdownString
 import com.pocket.ui.text.CustomTypefaceSpan
 import com.pocket.ui.text.Fonts
 import io.noties.markwon.AbstractMarkwonPlugin
@@ -12,37 +10,30 @@ import io.noties.markwon.MarkwonSpansFactory
 import org.commonmark.node.Emphasis
 import org.commonmark.node.StrongEmphasis
 
-class MarkdownHandler(
+class MarkdownFormatter(
     context: Context,
-    onLinkClicked: (link: String) -> Unit,
+    onLinkClicked: (context: Context, link: String) -> Unit,
 ) {
 
     private val markwon = Markwon.builder(context)
         .usePlugin(object : AbstractMarkwonPlugin() {
             override fun configureSpansFactory(builder: MarkwonSpansFactory.Builder) {
                 builder
-                    .setFactory(Emphasis::class.java) {_, _ ->
+                    .setFactory(Emphasis::class.java) { _, _ ->
                         CustomTypefaceSpan(Fonts.get(context, Fonts.Font.GRAPHIK_LCG_REGULAR_ITALIC))
                     }
-                    .setFactory(StrongEmphasis::class.java) {_, _ ->
+                    .setFactory(StrongEmphasis::class.java) { _, _ ->
                         CustomTypefaceSpan(Fonts.get(context, Fonts.Font.GRAPHIK_LCG_MEDIUM))
                     }
             }
 
             override fun configureConfiguration(builder: MarkwonConfiguration.Builder) {
-                builder.linkResolver { _, link ->
-                    onLinkClicked(link)
+                builder.linkResolver { view, link ->
+                    onLinkClicked(view.context, link)
                 }
             }
         })
         .build()
 
-    private val parser = MarkdownString.Parser { mdString ->
-        val node = markwon.parse(mdString.value)
-        markwon.render(node)
-    }
-
-    fun TextView.setMarkdownString(markdownString: MarkdownString) {
-        markwon.setParsedMarkdown(this, markdownString.parsed(parser))
-    }
+    fun format(markdown: String) = markwon.toMarkdown(markdown)
 }

--- a/Pocket/src/main/java/com/pocket/util/android/view/DataBindingCommons.kt
+++ b/Pocket/src/main/java/com/pocket/util/android/view/DataBindingCommons.kt
@@ -8,8 +8,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.widget.ImageViewCompat
 import androidx.databinding.BindingAdapter
 import com.pocket.app.App
-import com.pocket.sdk.api.value.MarkdownString
-import com.pocket.sdk.util.MarkdownHandler
+import com.pocket.sdk.util.MarkdownFormatter
 import com.pocket.ui.view.themed.ThemedTextView
 
 @BindingAdapter("visibility")
@@ -37,10 +36,7 @@ fun setTextUnderline(view: TextView, enabled: Boolean) {
 
 @BindingAdapter("textMarkdown")
 fun setTextMarkdown(view: ThemedTextView, markdown: String) {
-    with(MarkdownHandler(view.context) { App.viewUrl(view.context, it) }) {
-        view.setMarkdownString(MarkdownString(markdown))
-    }
-
+    view.text = MarkdownFormatter(view.context, App::viewUrl).format(markdown)
 }
 
 @BindingAdapter("drawableId")

--- a/Pocket/src/main/res/layout/fragment_authentication.xml
+++ b/Pocket/src/main/res/layout/fragment_authentication.xml
@@ -75,6 +75,7 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/continueSignedOutButton"
+                app:movementMethodForLinks="@{true}"
                 app:textMarkdown="@{@string/authentication_legal_disclaimer}"
                 />
             <FrameLayout

--- a/pocket-ui/src/main/java/com/pocket/ui/view/themed/ThemedTextView.java
+++ b/pocket-ui/src/main/java/com/pocket/ui/view/themed/ThemedTextView.java
@@ -110,8 +110,12 @@ public class ThemedTextView extends AppCompatTextView implements VisualMargin, E
 		}
 	}
 
-	public void setMovementMethodForLinks() {
-		setMovementMethod(new FixedLinkMethod());
+	public void setMovementMethodForLinks(boolean enabled) {
+		if (enabled) {
+			setMovementMethod(new FixedLinkMethod());
+		} else {
+			setMovementMethod(getDefaultMovementMethod());
+		}
 	}
 	
 	@SuppressLint("ClickableViewAccessibility") // Super is always called, so this lint warning is too paranoid.


### PR DESCRIPTION
I started working on displaying Markdown again after a while. With a new round comes a new look at the Markdown handling/formatting API I created previously. As it often happens it felt.. more complicated than it needed to be:
* `setMarkdownString` defined as an extension on `TextView` was cute in theory, but because it's not a top level helper method, but has to be used with a class instance it resulted in a convoluted usage pattern: `with (markdown) { textView.setMarkdownString(content) } `. And it required passing the handler/formatter all the way to where the view is.
* I also tied it to `MarkdownString` which in theory is just a general value holder, but in practice lives in a sync engine module, so while it's not in principle, in practice it is or feels tied to the sync engine. Also, looks like all usages before this new addition in Notes, actually had to artificially create this "sync engine" wrapper, just to use Markdown formatting.

The change to a method that converts a string with markdown formatting to `Spanned`:
* makes the API shape simpler,
* allows to format markdown further up from the view and pass what is almost a data description of the formatted text,
* means we give up on some "auto-magic" handling Markwon (the Markdown library we use) can apply when it has access to the `TextView`, but I think it's a good trade-off that we have to for example explicitly set link movement methods or add more explicit binding from our `TextView`s to Markwon,
* while it's still a type native to legacy views, I think it opens up the possibility of converting it to composables.

> [!NOTE]
> By the way this fixes a long standing bug in Collections, where collection story excerpts weren't clickable. So to open a collection story you had to click on the card anywhere except on the excerpt (which was usually the largest part). This is an issue we fixed ages ago, where the default link "movement method" eagerly eats all clicks on a `TextView`, even outside of links and even if there are no links
> 
> So this is the trade-off of switching away from Markwon auto-magic. We switched to our own link movement method, which has had a fix/workaround for this issue for ages.

## References

<!-- Links to docs, tickets, designs if available -->

## PR Checklist
<!-- Items in comments are optional, please review them and uncomment any that apply to this PR. -->
Setup:
* [x] Described changes for automated release notes in PR title using
  [Conventional Commits](https://mozilla-hub.atlassian.net/wiki/spaces/PE/pages/390658939/Commit+Message+Standard) standard
* [x] Self Review (review, clean up, documentation)
* [x] Basic Self QA
<!--
* [ ] Feature flagged as needed to ensure this specific code is beta and production ready
* [ ] Added `ignore-for-release` label because:
  * (choose applicable reason or add your own, delete the rest)
  * this fixes or changes something introduced after the last public release
  * this is hidden behind a feature flag that is disabled in public builds
  * this is part of a larger body of work that needs to be called out only once in release notes
-->

Review:
* [ ] Code Review approved
<!--
* [ ] If modified GraphQL spec or queries, checked the usage file for invalid or no longer used definitions and [cleaned it up](https://mozilla-hub.atlassian.net/wiki/spaces/PE/pages/390645389/Development+Workflow#Final-checks) if necessary
-->

<!-- Optional section for cases where we might need to do some tasks after the code is approved and merged.
After merge:
* [ ] Create the new feature flag in [Unleash](https://featureflags.readitlater.com/).
* [ ] Archive the deleted feature flag in [Unleash](https://featureflags.readitlater.com/).
* [ ] Update [Pocket Analytics spreadsheet](https://docs.google.com/spreadsheets/d/10DrvRWaRjHbhvdoetVqeScK452alaSUtXpgdLGtEs3A/edit).
-->

<!-- If you opened this PR with `git spr` feel free to copy anything it generated here into the PR body.
If you haven't used `git spr` or don't even know what it is feel free to ignore it or remove it from your PR.

Please don't remove it from PR template, unless you confirm with the team that nobody is using `git spr` anymore.

See:
* `.spr.yml` in this repo
* https://github.com/ejoffe/spr
spr -->
