### PR TITLE
fix(locale): use english if it's the default instead of second system language

### DIFF
--- a/Pocket/build.gradle.kts
+++ b/Pocket/build.gradle.kts
@@ -63,13 +63,28 @@ android {
         versionName = "$versionMajor.$versionMinor.$versionPatch.$versionBuild"
 
         vectorDrawables.useSupportLibrary = true // https://medium.com/@chrisbanes/appcompat-v23-2-age-of-the-vectors-91cbafa87c88#.m9i38hx27
+        resourceConfigurations.addAll(
+            arrayOf(
+                "de",
+                "es",
+                "es-rES",
+                "fr",
+                "fr-rCA",
+                "it",
+                "ja",
+                "ko",
+                "nl",
+                "pl",
+                "pt",
+                "pt-rBR",
+                "ru",
+                "zh",
+                "zh-rCN",
+                "zh-rTW"
+            )
+        )
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    androidResources {
-        localeFilters += listOf("de", "es", "es-rES", "fr", "fr-rCA", "it", "ja", "ko", "nl", "pl", "pt", "pt-rBR", "ru", "zh", "zh-rCN", "zh-rTW")
-        generateLocaleConfig = true
     }
 
     flavorDimensions.add(FlavorDimensions.TARGET)

--- a/Pocket/src/main/AndroidManifest.xml
+++ b/Pocket/src/main/AndroidManifest.xml
@@ -57,6 +57,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/nm_icon"
         android:theme="@style/Theme.PocketDefault"
+        android:localeConfig="@xml/locale_config"
         android:networkSecurityConfig="@xml/network_security_config">
 
         <!-- Declaring support for larger aspect ratios than the default 1.86 (including Galaxy S8). see https://android-developers.googleblog.com/2017/03/update-your-app-to-take-advantage-of.html -->

--- a/Pocket/src/main/res/resources.properties
+++ b/Pocket/src/main/res/resources.properties
@@ -1,1 +1,0 @@
-unqualifiedResLocale=en

--- a/Pocket/src/main/res/xml/locale_config.xml
+++ b/Pocket/src/main/res/xml/locale_config.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <locale android:name="en" />
+    <locale android:name="de" />
+    <locale android:name="es" />
+    <locale android:name="es-ES" />
+    <locale android:name="fr" />
+    <locale android:name="fr-CA" />
+    <locale android:name="it" />
+    <locale android:name="ja" />
+    <locale android:name="ko" />
+    <locale android:name="nl" />
+    <locale android:name="pl" />
+    <locale android:name="pt" />
+    <locale android:name="pt-BR" />
+    <locale android:name="ru" />
+    <locale android:name="zh" />
+    <locale android:name="zh-TW" />
+</locale-config>


### PR DESCRIPTION
This reverts commit e97990cf1bf7b76ac1dedcd09b7b6c18aaddaf8b.

Turns out switching to generated locale config file messed things up not just on my test device. Looks like for some reason Android skips over English if it's the default system language and uses the second configured system language instead 🤷 

## References

<!-- Links to docs, tickets, designs if available -->

## PR Checklist
<!-- Items in comments are optional, please review them and uncomment any that apply to this PR. -->
Setup:
* [x] Described changes for automated release notes in PR title using
  [Conventional Commits](https://mozilla-hub.atlassian.net/wiki/spaces/PE/pages/390658939/Commit+Message+Standard) standard
* [x] Self Review (review, clean up, documentation)
* [ ] Basic Self QA
<!--
* [ ] Feature flagged as needed to ensure this specific code is beta and production ready
* [ ] Added `ignore-for-release` label because:
  * (choose applicable reason or add your own, delete the rest)
  * this fixes or changes something introduced after the last public release
  * this is hidden behind a feature flag that is disabled in public builds
  * this is part of a larger body of work that needs to be called out only once in release notes
-->

Review:
* [ ] Code Review approved
<!--
* [ ] If modified GraphQL spec or queries, checked the usage file for invalid or no longer used definitions and [cleaned it up](https://mozilla-hub.atlassian.net/wiki/spaces/PE/pages/390645389/Development+Workflow#Final-checks) if necessary
-->

<!-- Optional section for cases where we might need to do some tasks after the code is approved and merged.
After merge:
* [ ] Create the new feature flag in [Unleash](https://featureflags.readitlater.com/).
* [ ] Archive the deleted feature flag in [Unleash](https://featureflags.readitlater.com/).
* [ ] Update [Pocket Analytics spreadsheet](https://docs.google.com/spreadsheets/d/10DrvRWaRjHbhvdoetVqeScK452alaSUtXpgdLGtEs3A/edit).
-->

<!-- If you opened this PR with `git spr` feel free to copy anything it generated here into the PR body.
If you haven't used `git spr` or don't even know what it is feel free to ignore it or remove it from your PR.

Please don't remove it from PR template, unless you confirm with the team that nobody is using `git spr` anymore.

See:
* `.spr.yml` in this repo
* https://github.com/ejoffe/spr
spr -->
