### PR TITLE
build(deps): switch to r8 shipped with agp

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -11,15 +11,9 @@ plugins {
 
 repositories {
     exclusiveContent {
-        forRepository { r8() }
-        filter {
-            includeModule("com.android.tools", "r8")
-        }
-    }
-    exclusiveContent {
         forRepository { google() }
         filter {
-            includeModuleByRegex("^com\\.android.*", "^(?!r8\$).*")
+            includeGroupByRegex("^com\\.android.*")
             includeGroupByRegex("^androidx.*")
             includeGroupByRegex("com\\.google\\.testing.*")
         }
@@ -29,7 +23,6 @@ repositories {
 }
 
 dependencies {
-    implementation(libs.r8)
     implementation(libs.plugin.android)
     implementation(libs.plugin.kotlin)
     implementation(libs.plugin.kotlin.compose)
@@ -40,9 +33,4 @@ dependencies {
     implementation(libs.plugin.dagger)
     implementation(libs.plugin.androidx.navigation.safeargs)
     implementation(libs.plugin.sentry)
-}
-
-fun RepositoryHandler.r8() = maven {
-    name = "R8 releases"
-    url = uri("https://storage.googleapis.com/r8-releases/raw")
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -69,7 +69,6 @@ plugin-kotlin-serialization = { module = "org.jetbrains.kotlin:kotlin-serializat
 plugin-licensee = { module = "app.cash.licensee:licensee-gradle-plugin", version = "1.12.0" }
 plugin-sentry = { module = "io.sentry:sentry-android-gradle-plugin", version = "5.3.0" }
 plugin-versions = { module = "com.github.ben-manes:gradle-versions-plugin", version = "0.52.0" }
-r8 = { module = "com.android.tools:r8", version = "8.8.40" }
 robolectric = { module = "org.robolectric:robolectric", version = "4.14.1" }
 sentry = { module = "io.sentry:sentry-android" }
 sentry-bom = { module = "io.sentry:sentry-bom", version = "8.5.0" }

--- a/renovate.json5
+++ b/renovate.json5
@@ -28,17 +28,6 @@
       matchManagers: ['gradle', 'gradle-wrapper'],
       commitMessageTopic: '{{depName}}',
     },
-    // Use a custom R8 datasource, because R8 repository is not a full Maven repository
-    // and doesn't expose available versions for Renovate.
-    {
-      matchPackageNames: [
-        'com.android.tools:r8'
-      ],
-      overrideDatasource: 'custom.r8',
-      registryUrls: [
-        'https://r8.googlesource.com/r8/+log/refs/heads/8.8/src/main/java/com/android/tools/r8/Version.java?format=HTML'
-      ],
-    },
   ],
   customManagers: [
     // Update .java-version file with the latest JDK version.
@@ -57,26 +46,4 @@
       extractVersionTemplate: '^(?<version>\\d+)',
     },
   ],
-  customDatasources: {
-    // Check the available r8 versions from a specific release branch in the r8 repository,
-    // by extracting them from commit messages.
-    r8: {
-      // Workaround: This requests an HTML response (via the query parameter in the URL),
-      // but instructs Renovate to treat it as plain text, to do some custom processing
-      // with JSONata and regex, instead of relying on the default HTML processing.
-      format: 'plain',
-      transformTemplates: [
-        '{\
-            "releases": $split(releases[0].version, "<li class=\\"CommitLog-item ")\
-                .($match(/([^"\\/]+)">Version ([0-9\\.]+)<\\/a>/))\
-                .{\
-                    "digest": groups[0],\
-                    "version": groups[1],\
-                    "isStable": true\
-                },\
-            "sourceUrl": "https://r8.googlesource.com/r8/"\
-        }'
-      ],
-    }
-  },
 }


### PR DESCRIPTION
Trying to stay on the latest "stable" R8 seems to be more hassle than it's worth. Going back to using R8 version shipped with AGP.

## References

<!-- Links to docs, tickets, designs if available -->

## PR Checklist
<!-- Items in comments are optional, please review them and uncomment any that apply to this PR. -->
Setup:
* [x] Described changes for automated release notes in PR title using
  [Conventional Commits](https://mozilla-hub.atlassian.net/wiki/spaces/PE/pages/390658939/Commit+Message+Standard) standard
* [x] Self Review (review, clean up, documentation)
* [x] Basic Self QA
<!--
* [ ] Feature flagged as needed to ensure this specific code is beta and production ready
* [ ] Added `ignore-for-release` label because:
  * (choose applicable reason or add your own, delete the rest)
  * this fixes or changes something introduced after the last public release
  * this is hidden behind a feature flag that is disabled in public builds
  * this is part of a larger body of work that needs to be called out only once in release notes
-->

Review:
* [ ] Code Review approved
<!--
* [ ] If modified GraphQL spec or queries, checked the usage file for invalid or no longer used definitions and [cleaned it up](https://mozilla-hub.atlassian.net/wiki/spaces/PE/pages/390645389/Development+Workflow#Final-checks) if necessary
-->

<!-- Optional section for cases where we might need to do some tasks after the code is approved and merged.
After merge:
* [ ] Create the new feature flag in [Unleash](https://featureflags.readitlater.com/).
* [ ] Archive the deleted feature flag in [Unleash](https://featureflags.readitlater.com/).
* [ ] Update [Pocket Analytics spreadsheet](https://docs.google.com/spreadsheets/d/10DrvRWaRjHbhvdoetVqeScK452alaSUtXpgdLGtEs3A/edit).
-->

<!-- If you opened this PR with `git spr` feel free to copy anything it generated here into the PR body.
If you haven't used `git spr` or don't even know what it is feel free to ignore it or remove it from your PR.

Please don't remove it from PR template, unless you confirm with the team that nobody is using `git spr` anymore.

See:
* `.spr.yml` in this repo
* https://github.com/ejoffe/spr
spr -->
